### PR TITLE
typo: protc is not found

### DIFF
--- a/configure
+++ b/configure
@@ -2261,7 +2261,7 @@ then
 else
   printf 'no\n'
   printf '#================================================================\n' 1>&2
-  printf '# WARNING: protc is not found.\n' 1>&2
+  printf '# WARNING: protoc is not found.\n' 1>&2
   printf '#================================================================\n' 1>&2
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -145,7 +145,7 @@ then
 else
   printf 'no\n'
   printf '#================================================================\n' 1>&2
-  printf '# WARNING: protc is not found.\n' 1>&2
+  printf '# WARNING: protoc is not found.\n' 1>&2
   printf '#================================================================\n' 1>&2
 fi
 


### PR DESCRIPTION
This PR is to fix a typo in a message in `configure`.

The WARNING sounds weak and looks not enough as `protoc` is required to build `tkrzw-rpc` from source, by the way.

