### PR TITLE
Make it compile on FreeBSD

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -217,11 +217,11 @@ AC_CHECK_LIB(lzma, main)
 AC_CHECK_LIB(tkrzw, main)
 AC_CHECK_LIB(protobuf, main)
 AC_CHECK_LIB(gpr, main)
+AC_CHECK_LIB(absl_synchronization, main)
 AC_CHECK_LIB(grpc, main)
 AC_CHECK_LIB(grpc++, main)
 AC_CHECK_LIB(grpc++_reflection, main)
 AC_CHECK_LIB(tkrzw_rpc, main, AC_MSG_WARN([old version of Tkrzw-RPC was detected])) 
-AC_CHECK_LIB(absl_synchronization, main)
 MYLDLIBPATH="$LD_LIBRARY_PATH"
 
 # Necessary headers

--- a/configure.in
+++ b/configure.in
@@ -221,6 +221,7 @@ AC_CHECK_LIB(grpc, main)
 AC_CHECK_LIB(grpc++, main)
 AC_CHECK_LIB(grpc++_reflection, main)
 AC_CHECK_LIB(tkrzw_rpc, main, AC_MSG_WARN([old version of Tkrzw-RPC was detected])) 
+AC_CHECK_LIB(absl_synchronization, main)
 MYLDLIBPATH="$LD_LIBRARY_PATH"
 
 # Necessary headers


### PR DESCRIPTION
The code uses absl::lts_20210324::Mutex::* stuff, which is in the absl_synchronization library provided on FreeBSD by the port devel/abseil, however the library was not linked in.
I kindly ask you to check that this does not cause a regression on other platforms (I cannot test on Linux right now), it should not.
With this patch tkrzw-rpc compiles nicely on FreeBSD using LLVM and following the README instructions, no need to fall back to GCC.